### PR TITLE
Update Bootstrap URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.vscode
 *.pyc
 chain.txt
 venv/

--- a/blockchain/chain.py
+++ b/blockchain/chain.py
@@ -26,10 +26,14 @@ class Block:
     """
         Create a new block in chain with metadata
     """
-    def __init__(self, data, index=0):
+    def __init__(self, uid_epita, email_epita, nom, prenom, image, index=0):
         self.index = index
         self.previousHash = ""
-        self.data = data
+        self.uid_epita = uid_epita
+        self.email_epita = email_epita
+        self.nom = nom
+        self.prenom = prenom
+        self.image = image
         self.timestamp = str(datetime.datetime.now())
         self.nonce = 0
         self.hash = self.calculateHash()
@@ -38,7 +42,7 @@ class Block:
         """
             Method to calculate hash from metadata
         """
-        hashData = str(self.index) + str(self.data) + self.timestamp + self.previousHash + str(self.nonce)
+        hashData = str(self.index) + str(self.uid_epita) + str(self.email_epita) + str(self.nom) + str(self.prenom) + str(self.image) + self.timestamp + self.previousHash + str(self.nonce)
         return hashlib.sha256(hashData).hexdigest()
 
     def mineBlock(self, difficulty):
@@ -72,7 +76,7 @@ class Blockchain:
         """
             Method create genesis block
         """
-        return Block("Genesis Block")
+        return Block("Genesis Block", "None", "None", "None", "None")
 
     def addBlock(self, newBlock):
         """

--- a/bscli.py
+++ b/bscli.py
@@ -93,7 +93,8 @@ def dotx(cmd):
     if "{" in txData:
         txData = json.loads(txData)
     print "Doing transaction..."
-    coin.addBlock(Block(data=txData))
+    datas = txData.split(" ")
+    coin.addBlock(Block(datas[0], datas[1], datas[2], datas[3], datas[4]))
 
 def allblocks(cmd):
     """

--- a/templates/blockdata.html
+++ b/templates/blockdata.html
@@ -7,8 +7,7 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | Block Data</title>
         <!-- Bootstrap core CSS -->
-        <link href="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;
@@ -130,7 +129,8 @@
             <p>Project by <a href="https://daxeel.github.io" target="_blank">Daxeel Soni</a></p>
             </footer> -->
         <!-- Bootstrap core JavaScript -->
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/jquery/jquery.min.js"></script>
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     </body>
 </html>

--- a/templates/blockdata.html
+++ b/templates/blockdata.html
@@ -7,7 +7,8 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | Block Data</title>
         <!-- Bootstrap core CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous"> 
+        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;

--- a/templates/blockdata.html
+++ b/templates/blockdata.html
@@ -66,8 +66,24 @@
                             <td>{{data['timestamp']}}</td>
                         </tr>
                         <tr>
-                            <td><b>Data</b></td>
-                            <td>{{data['data']}}</td>
+                            <td><b>uid_epita</b></td>
+                            <td>{{data['uid_epita']}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>email_epita</b></td>
+                            <td>{{data['email_epita']}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>nom</b></td>
+                            <td>{{data['nom']}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>prenom</b></td>
+                            <td>{{data['prenom']}}</td>
+                        </tr>
+                        <tr>
+                            <td><b>image</b></td>
+                            <td>{{data['image']}}</td>
                         </tr>
                         <tr>
                             <td><b>Hash</b></td>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -7,7 +7,8 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | All Blocks</title>
         <!-- Bootstrap core CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -7,8 +7,7 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | All Blocks</title>
         <!-- Bootstrap core CSS -->
-        <link href="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;
@@ -108,7 +107,8 @@
             <p>Project by <a href="https://daxeel.github.io" target="_blank">Daxeel Soni</a></p>
             </footer> -->
         <!-- Bootstrap core JavaScript -->
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/jquery/jquery.min.js"></script>
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     </body>
 </html>

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -7,7 +7,8 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | All Blocks</title>
         <!-- Bootstrap core CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -7,8 +7,7 @@
         <meta name="author" content="Daxeel Soni">
         <title>Blockshell | All Blocks</title>
         <!-- Bootstrap core CSS -->
-        <link href="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-        <!-- Custom styles for this template -->
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">        <!-- Custom styles for this template -->
         <style>
             body {
             padding-top: 54px;
@@ -173,7 +172,8 @@
             <p>Project by <a href="https://daxeel.github.io" target="_blank">Daxeel Soni</a></p>
             </footer> -->
         <!-- Bootstrap core JavaScript -->
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/jquery/jquery.min.js"></script>
-        <script src="https://blackrockdigital.github.io/startbootstrap-bare/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     </body>
 </html>


### PR DESCRIPTION
Hi everyone,

The URLs use to import Bootstrap are no longer available. It has been changed for the new ones so the BlockShell Web Explorer can use Bootstrap CSS en JavaScript again.